### PR TITLE
searchCriteria default value added as all

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -160,7 +160,7 @@ export default class MagentoRestApi {
         if (params && Object.keys(params).length > 0) {
             endpoint += '?' + this._searchTranslate(params);
         } else {
-            endpoint += '?searchCriteria=all'
+            endpoint += '?searchCriteria='
         }
         return this._formRequest('GET', endpoint);
     }

--- a/index.mjs
+++ b/index.mjs
@@ -160,7 +160,7 @@ export default class MagentoRestApi {
         if (params && Object.keys(params).length > 0) {
             endpoint += '?' + this._searchTranslate(params);
         } else {
-            endpoint += '?searchCriteria'
+            endpoint += '?searchCriteria=all'
         }
         return this._formRequest('GET', endpoint);
     }

--- a/index.spec.js
+++ b/index.spec.js
@@ -105,7 +105,7 @@ describe('# Requests', function () {
     });
 
     it('should execute get requests without params non https', async function () {
-        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=all', {
+        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=', {
             status: 200,
             response: {
                 success: true,
@@ -127,7 +127,7 @@ describe('# Requests', function () {
             'tokenSecret': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
         });
 
-        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=all', {
+        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=', {
             status: 200,
             response: {
                 success: true,
@@ -149,7 +149,7 @@ describe('# Requests', function () {
             'tokenSecret': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
         });
 
-        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=all', {
+        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=', {
             status: 200,
             response: {
                 success: true,
@@ -163,7 +163,7 @@ describe('# Requests', function () {
     });
 
     it('should execute get requests with empty object params https', async function () {
-        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=all', {
+        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=', {
             status: 200,
             response: {
                 success: true,
@@ -202,7 +202,7 @@ describe('# Requests', function () {
             'sha': 256
         });
 
-        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=all', {
+        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=', {
             status: 200,
             response: {
                 success: true,

--- a/index.spec.js
+++ b/index.spec.js
@@ -105,7 +105,7 @@ describe('# Requests', function () {
     });
 
     it('should execute get requests without params non https', async function () {
-        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria', {
+        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=all', {
             status: 200,
             response: {
                 success: true,
@@ -127,7 +127,7 @@ describe('# Requests', function () {
             'tokenSecret': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
         });
 
-        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=', {
+        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=all', {
             status: 200,
             response: {
                 success: true,
@@ -149,7 +149,7 @@ describe('# Requests', function () {
             'tokenSecret': 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
         });
 
-        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=', {
+        moxios.stubRequest('http://magento.dev/rest/V1/orders?searchCriteria=all', {
             status: 200,
             response: {
                 success: true,
@@ -163,7 +163,7 @@ describe('# Requests', function () {
     });
 
     it('should execute get requests with empty object params https', async function () {
-        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria', {
+        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=all', {
             status: 200,
             response: {
                 success: true,
@@ -202,7 +202,7 @@ describe('# Requests', function () {
             'sha': 256
         });
 
-        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria', {
+        moxios.stubRequest('https://magento.dev/rest/V1/orders?searchCriteria=all', {
             status: 200,
             response: {
                 success: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magento-api-rest",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A NodeJS wrapper to work with Magento REST APIs.",
   "main": "index",
   "types": "index.d.ts",


### PR DESCRIPTION
I encountered problems while upgrading from version 1.1.1 to 2.0.4, receiving the error message: `The signature is invalid. Verify and try again.` Despite the signature being correct, the issue was caused by an empty searchCriteria. To resolve this, I applied a patch.